### PR TITLE
sim_factory.h and improve memory efficiency of simulation.cc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,10 @@ cc_binary(
 
 cc_library(
     name = "cache_sim",
-    hdrs = ["cache_sim.h"],
+    hdrs = [
+        "cache_sim.h",
+        "sim_factory.h",
+    ],
     deps = [
         "@absl//absl/time:time",
     ],

--- a/sim_factory.h
+++ b/sim_factory.h
@@ -1,0 +1,37 @@
+#ifndef ONLINE_CACHE_SIMULATOR_SIM_FACTORY_H_
+#define ONLINE_CACHE_SIMULATOR_SIM_FACTORY_H_
+
+#include "container_cache_sim.h"
+#include "iak_wrapper.h"
+#include "increment_and_freeze.h"
+#include "ost_cache_sim.h"
+
+// An enum describing the different CacheSims
+enum CacheSimType {
+  OS_TREE,
+  OS_SET,
+  IAK,
+  CHUNK_IAK,
+};
+
+std::unique_ptr<CacheSim> new_simulator(CacheSimType sim_enum, size_t min_chunk = 65536,
+                                        size_t mem_limit = 0) {
+  switch (sim_enum) {
+    case OS_TREE:
+      return std::make_unique<OSTCacheSim>();
+    case OS_SET:
+      return std::make_unique<ContainerCacheSim>();
+    case IAK:
+      return std::make_unique<IncrementAndFreeze>();
+    case CHUNK_IAK:
+      if (mem_limit != 0)
+        return std::make_unique<IAKWrapper>(min_chunk, mem_limit);
+      else
+        return std::make_unique<IAKWrapper>(min_chunk);
+    default:
+      std::cerr << "ERROR: Unrecognized sim_enum!" << std::endl;
+      exit(EXIT_FAILURE);
+  }
+}
+
+#endif  // ONLINE_CACHE_SIMULATOR_SIM_FACTORY_H_

--- a/unit_tests.cc
+++ b/unit_tests.cc
@@ -1,32 +1,5 @@
 #include "gtest/gtest.h"
-#include "iak_wrapper.h"
-#include "increment_and_freeze.h"
-#include "ost_cache_sim.h"
-#include "container_cache_sim.h"
-
-// An enum describing the different CacheSims
-enum CacheSimType {
-  OS_TREE,
-  OS_SET,
-  IAK,
-  CHUNK_IAK,
-};
-
-std::unique_ptr<CacheSim> new_simulator(CacheSimType sim_enum) {
-  switch(sim_enum) {
-    case OS_TREE:
-      return std::make_unique<OSTCacheSim>();
-    case OS_SET:
-      return std::make_unique<ContainerCacheSim>();
-    case IAK:
-      return std::make_unique<IncrementAndFreeze>();
-    case CHUNK_IAK:
-      return std::make_unique<IAKWrapper>();
-    default:
-      std::cerr << "ERROR: Unrecognized sim_enum!" << std::endl;
-      exit(EXIT_FAILURE);
-  }
-}
+#include "sim_factory.h"
 
 class CacheSimUnitTests : public testing::TestWithParam<CacheSimType> {
 


### PR DESCRIPTION
Simulation.cc is for testing the performance of our cache sims. Retaining SimResults across experiments bloats memory usage and limits the size of experiments we can run. If we want a test that verifies success functions we can do that but it should be a different executable.